### PR TITLE
ci(build): add permissions to job

### DIFF
--- a/.github/workflows/java.template.yml
+++ b/.github/workflows/java.template.yml
@@ -11,6 +11,10 @@ env:
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     


### PR DESCRIPTION
## Changes

In this PR I've specified the build job permissions to `contents: read` and `packages: write` so that the build agent is able to push the built docker container to ghcr.

## Why is this change needed?

Cloning this repository into my own account, the build pipeline would fail when trying to push the container to ghcr with the following message:

```
buildx failed with: ERROR: denied: installation not allowed to Create organization package
```

It was only after specifying the permissions the pipeline was able to push the container. When running the build pipeline, the permissions `GITHUB_TOKEN` originally had were:

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
```

After specifying the permissions:

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
  Packages: write
```